### PR TITLE
Add video generation notebook

### DIFF
--- a/generate_video.ipynb
+++ b/generate_video.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import math\n",
+    "from transformers import AutoModelForCausalLM\n",
+    "from torchvision.utils import save_image\n",
+    "import imageio, os\n",
+    "\n",
+    "run_device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# video settings\n",
+    "RESOLUTION_WIDTH = 128\n",
+    "RESOLUTION_HEIGHT = 128\n",
+    "CHANNELS = 3\n",
+    "BOTTLENECK_DIM = 768"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ImageCompressor:\n",
+    "    def __init__(self, resolution=(RESOLUTION_HEIGHT, RESOLUTION_WIDTH), channels=CHANNELS, latent_dim=BOTTLENECK_DIM):\n",
+    "        self.H, self.W = resolution\n",
+    "        self.C = channels\n",
+    "        self.latent_dim = latent_dim\n",
+    "        self.per_channel_dim = latent_dim // self.C\n",
+    "        scale_factor = math.sqrt(self.per_channel_dim / (self.H * self.W))\n",
+    "        self.h_down = max(1, int(self.H * scale_factor))\n",
+    "        self.w_down = max(1, int(self.W * scale_factor))\n",
+    "\n",
+    "    def encode(self, image):\n",
+    "        is_batched = image.dim() == 4\n",
+    "        if not is_batched:\n",
+    "            image = image.unsqueeze(0)\n",
+    "        B = image.shape[0]\n",
+    "        latent_parts = []\n",
+    "        for c in range(self.C):\n",
+    "            ch = image[:, c:c+1, :, :]\n",
+    "            down = F.interpolate(ch, size=(self.h_down, self.w_down), mode='bilinear', align_corners=False)\n",
+    "            flat = down.view(B, -1)\n",
+    "            if flat.shape[1] < self.per_channel_dim:\n",
+    "                pad = torch.zeros((B, self.per_channel_dim - flat.shape[1]), device=flat.device, dtype=flat.dtype)\n",
+    "                flat = torch.cat([flat, pad], dim=1)\n",
+    "            else:\n",
+    "                flat = flat[:, :self.per_channel_dim]\n",
+    "            latent_parts.append(flat)\n",
+    "        latent = torch.cat(latent_parts, dim=1)\n",
+    "        if not is_batched:\n",
+    "            latent = latent.squeeze(0)\n",
+    "        return latent\n",
+    "\n",
+    "    def decode(self, latent):\n",
+    "        is_batched = latent.dim() == 2\n",
+    "        if not is_batched:\n",
+    "            latent = latent.unsqueeze(0)\n",
+    "        B = latent.shape[0]\n",
+    "        per_channel_dim = self.per_channel_dim\n",
+    "        h_down, w_down = self.h_down, self.w_down\n",
+    "        H, W = self.H, self.W\n",
+    "        channels = []\n",
+    "        for i in range(self.C):\n",
+    "            start = i * per_channel_dim\n",
+    "            end = start + per_channel_dim\n",
+    "            flat = latent[:, start:end]\n",
+    "            ch = flat[:, :h_down * w_down].reshape(B, 1, h_down, w_down)\n",
+    "            up = F.interpolate(ch, size=(H, W), mode='bilinear', align_corners=False)\n",
+    "            channels.append(up)\n",
+    "        recon = torch.cat(channels, dim=1)\n",
+    "        if not is_batched:\n",
+    "            recon = recon.squeeze(0)\n",
+    "        return recon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load model\n",
+    "decap_gpt2 = AutoModelForCausalLM.from_pretrained('decap_gpt2_cm2').to(run_device)\n",
+    "compressor = ImageCompressor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_latent_sequence(model, sequence_length=600, latent_dim=BOTTLENECK_DIM, device=run_device):\n",
+    "    model.eval()\n",
+    "    with torch.no_grad():\n",
+    "        current = torch.zeros(1, 1, latent_dim, device=device)\n",
+    "        for _ in range(sequence_length):\n",
+    "            out = model(inputs_embeds=current).last_hidden_state\n",
+    "            next_latent = out[:, -1:, :]\n",
+    "            current = torch.cat([current, next_latent], dim=1)\n",
+    "        return current.squeeze(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def decode_latents_to_images(latents, output_folder='generated_video'):\n",
+    "    os.makedirs(output_folder, exist_ok=True)\n",
+    "    with torch.no_grad():\n",
+    "        for i, latent in enumerate(latents):\n",
+    "            img = compressor.decode(latent.unsqueeze(0)).clamp(0,1)\n",
+    "            save_image(img, os.path.join(output_folder, f'frame_{i:04d}.png'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_video_imageio(frame_folder='generated_video', output_file='output.mp4', fps=60):\n",
+    "    frames = sorted([os.path.join(frame_folder, f) for f in os.listdir(frame_folder) if f.endswith('.png')])\n",
+    "    writer = imageio.get_writer(output_file, fps=fps)\n",
+    "    for fp in frames:\n",
+    "        image = imageio.imread(fp)\n",
+    "        writer.append_data(image)\n",
+    "    writer.close()\n",
+    "    print(f'\u2705 Video saved using imageio: {output_file}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === RUN ===\n",
+    "latents = generate_latent_sequence(decap_gpt2, sequence_length=600)\n",
+    "decode_latents_to_images(latents)\n",
+    "make_video_imageio()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create a new notebook `generate_video.ipynb`
- load the previously saved `decap_gpt2_cm2` checkpoint
- define `ImageCompressor` from the predictor notebook
- generate a 10s 60fps sequence and encode it with `imageio`

## Testing
- `apt-get install -y ffmpeg`
- `pip install --force-reinstall --no-cache-dir torch==2.2.2+cpu torchvision==0.17.2+cpu torchaudio==2.2.2+cpu -f https://download.pytorch.org/whl/torch_stable.html`
- `pip install transformers imageio moviepy`


------
https://chatgpt.com/codex/tasks/task_e_684b79c201d483338f732e64b543ae75