### PR TITLE
Improve video seed mechanism

### DIFF
--- a/generate_video.ipynb
+++ b/generate_video.ipynb
@@ -12,6 +12,7 @@
     "import torch.nn.functional as F\n",
     "from transformers import GPT2Model\n",
     "import imageio, os\n",
+    "from PIL import Image\n",
     "\n",
     "run_device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')"
    ]
@@ -131,18 +132,38 @@
    "id": "52c1f7a0",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def generate_frames(num_frames=6000):\n",
-    "    seq = torch.zeros(1, 1, BOTTLENECK_DIM, device=run_device)\n",
-    "    frames = []\n",
-    "    with torch.no_grad():\n",
-    "        for _ in range(num_frames):\n",
-    "            out = transformer(inputs_embeds=seq).last_hidden_state\n",
-    "            next_latent = out[:, -1:, :]\n",
-    "            frame = autoenc.decode(next_latent.squeeze(1)).clamp(-1, 1)\n",
-    "            frames.append(frame.cpu())\n",
-    "            seq = torch.cat([seq, next_latent], dim=1)[:, -16:, :]\n",
-    "    return frames\n",
+    "source": [
+     "def generate_frames(num_frames=6000, seed_folder='video_dataset', seed_count=4):\n",
+     "    \"\"\"Generate video frames. The first `seed_count` frames are obtained by\n",
+     "    encoding frames from `seed_folder` if available.\n",
+     "    \"\"\"\n",
+     "    frames = []\n",
+     "    latents = []\n",
+     "    if os.path.isdir(seed_folder):\n",
+     "        videos = [f for f in os.listdir(seed_folder) if f.endswith('.mp4')]\n",
+     "        if videos:\n",
+     "            reader = imageio.get_reader(os.path.join(seed_folder, videos[0]))\n",
+     "            for i, img in enumerate(reader):\n",
+     "                if i >= seed_count:\n",
+     "                    break\n",
+     "                t = torch.from_numpy(img).permute(2,0,1).float() / 127.5 - 1\n",
+     "                frames.append(t.unsqueeze(0))\n",
+     "                latents.append(autoenc.encode(t.unsqueeze(0).to(run_device)))\n",
+     "            reader.close()\n",
+     "    if not latents:\n",
+     "        for _ in range(seed_count):\n",
+     "            z = torch.randn(1, BOTTLENECK_DIM, device=run_device)\n",
+     "            latents.append(z)\n",
+     "            frames.append(autoenc.decode(z).clamp(-1,1).cpu())\n",
+     "    seq = torch.stack(latents, dim=1)\n",
+     "    with torch.no_grad():\n",
+     "        for _ in range(num_frames - seed_count):\n",
+     "            out = transformer(inputs_embeds=seq).last_hidden_state\n",
+     "            next_latent = out[:, -1:, :]\n",
+     "            frame = autoenc.decode(next_latent.squeeze(1)).clamp(-1, 1)\n",
+     "            frames.append(frame.cpu())\n",
+     "            seq = torch.cat([seq, next_latent], dim=1)[:, -16:, :]\n",
+     "    return frames\n",
     "\n",
     "def save_video(frames, output='output.mp4', fps=60):\n",
     "    writer = imageio.get_writer(output, fps=fps)\n",
@@ -168,10 +189,10 @@
      ]
     }
    ],
-   "source": [
-    "frames = generate_frames()\n",
-    "save_video(frames)"
-   ]
+     "source": [
+      "frames = generate_frames(seed_count=4)\n",
+      "save_video(frames)"
+     ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- seed generation with dataset frames when available
- fallback to random latents if dataset is missing
- document new `seed_count` argument

## Testing
- `python3 - <<'EOF'
import json, sys
with open('generate_video.ipynb') as f:
    nb=json.load(f)
for cell in nb['cells']:
    if cell['cell_type']=='code':
        compile(''.join(cell['source']), '<cell>', 'exec')
print('All cells compiled')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6850278a1a5483338e261f262aa849a7